### PR TITLE
[ADD] Package required by OCA/server-backend

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y --no-install-recommends \
         postgresql-client wget git tcl gcc bzip2 expect-dev \
         python-lxml libxmlsec1-dev pkg-config libsasl2-dev \
         libldap2-dev libxml2-dev libxslt-dev zlib1g-dev libcups2-dev \
-        openssh-client \
+        openssh-client default-libmysqlclient-dev \
         && rm -rf /var/lib/apt/lists/* \
         && apt-get clean
 RUN wget -q -O - https://deb.nodesource.com/setup_10.x | bash -

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y --no-install-recommends \
         postgresql-client wget git tcl gcc bzip2 expect-dev \
         python-lxml libxmlsec1-dev pkg-config libsasl2-dev \
         libldap2-dev libxml2-dev libxslt-dev zlib1g-dev libcups2-dev \
-        openssh-client \
+        openssh-client default-libmysqlclient-dev \
         && rm -rf /var/lib/apt/lists/* \
         && apt-get clean
 RUN wget -q -O - https://deb.nodesource.com/setup_10.x | bash -


### PR DESCRIPTION
This package is mandatory to be able to run `pip install mysqlclient`

### Changes proposed in this PR:

* Add mandatory package

### State

- [X] READY :tada:
- [ ] WIP :computer::alien::exclamation:

### How to test the changes


### Extra notes
This is a side effect if you are using `OCA/reporting-engine` because depends on `OCA/server-backend`
