### PR TITLE
[FIX] merge_prs: warning: refname 'XXX' is ambiguous

### DIFF
--- a/bin/merge_prs
+++ b/bin/merge_prs
@@ -29,7 +29,7 @@ def merge(repo, prs):
             "rev-list",
             "--count",
             "--no-merges",
-            "origin/%s..%s" % (os.environ["VERSION"], pr),
+            "origin/%s..heads/%s" % (os.environ["VERSION"], pr),
         ]
         p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE, encoding="utf8")
         out, error = p.communicate()


### PR DESCRIPTION
### Changes proposed in this PR:

* [FIX] merge_prs: warning: refname 'XXX' is ambiguous

### State

- [x] READY :tada:
- [ ] WIP :computer::alien::exclamation:

### How to test the changes


### Extra notes
